### PR TITLE
Support for moving chat div

### DIFF
--- a/background.js
+++ b/background.js
@@ -199,6 +199,7 @@ chrome.runtime.onMessage.addListener((message, sender, callback) => {
           type: 'twitch',
           winId: sender.tab.windowId,
           version: 0,
+          x: message.rect.x + 1,
           name: matchChannelName(sender.tab.url),
         };
         let port = getPort();
@@ -219,6 +220,7 @@ chrome.runtime.onMessage.addListener((message, sender, callback) => {
         // get zoom value
         chrome.tabs.getZoom(sender.tab.id, (zoom) => {
           let size = {
+            x: message.rect.x,
             width: Math.floor(message.rect.width * zoom),
             height: Math.floor(message.rect.height * zoom),
           };


### PR DESCRIPTION
I added the x position of the chat div to the message being passed to the Chatterino application. This allows Chatterino to adjust the overlay position according to where the chat div is instead of using a static position.

Enables Chatterino/chatterino2#1825

Before:
![image](https://user-images.githubusercontent.com/44077383/88467945-837fec00-ce91-11ea-977c-a50fa286cc98.png)
With this:
![image](https://user-images.githubusercontent.com/44077383/88467955-9d213380-ce91-11ea-9a85-d315ff2a7ff1.png)
