### PR TITLE
Fixed blank area with new layout.

### DIFF
--- a/background.js
+++ b/background.js
@@ -199,7 +199,6 @@ chrome.runtime.onMessage.addListener((message, sender, callback) => {
           type: 'twitch',
           winId: sender.tab.windowId,
           version: 0,
-          x: message.rect.x + 1,
           name: matchChannelName(sender.tab.url),
         };
         let port = getPort();

--- a/inject.js
+++ b/inject.js
@@ -38,7 +38,7 @@
     return undefined;
   }
 
-  let findChatDiv = () => document.getElementsByClassName('right-column')[0];
+  let findChatDiv = () => document.getElementsByClassName('chat-shell')[0];
   let findRightCollapse = () =>
     document.getElementsByClassName('right-column__toggle-visibility')[0].children[0];
   let findRightColumn = () =>
@@ -76,7 +76,7 @@
 
       window.chatDiv = x;
 
-      if (x != undefined && x.children.length >= 2) {
+      if (x != undefined && x.children.length >= 1) {
         x.children[0].innerHTML =
           '<div style="width: 340px; height: 100%; justify-content: center; display: flex; flex-direction: column; text-align: center; color: #999; user-select: none; background: #222;"></div>';
 


### PR DESCRIPTION
I wanted to fix the big blank area present when using the extension with the new layout. I replaced a div further down in the DOM than before. 

I tested this on Windows 10 in Chrome and Firefox and it appears to fix the problem. 

Before: 
![image](https://user-images.githubusercontent.com/44077383/89227340-5965b280-d592-11ea-8c85-1d640745a4ae.png)

With these changes:
![image](https://user-images.githubusercontent.com/44077383/89227384-6e424600-d592-11ea-8b97-d40f49c71d67.png)

Fixes: #17