### PR TITLE
Fixed position bug when zooming [Chrome]

### DIFF
--- a/background.js
+++ b/background.js
@@ -220,6 +220,7 @@ chrome.runtime.onMessage.addListener((message, sender, callback) => {
         chrome.tabs.getZoom(sender.tab.id, (zoom) => {
           let size = {
             x: message.rect.x,
+            pixelRatio: message.pixelRatio,
             width: Math.floor(message.rect.width * zoom),
             height: Math.floor(message.rect.height * zoom),
           };

--- a/inject.js
+++ b/inject.js
@@ -174,6 +174,7 @@
 
     let data = {
       type: 'chat-resized',
+      pixelRatio: window.devicePixelRatio,
       rect: { x: rect.x, y: rect.y, width: rect.width, height: rect.height },
     };
 
@@ -231,7 +232,7 @@
 
   // event listeners
   window.addEventListener('load', () => setTimeout(queryChatRect, 1000));
-  window.addEventListener('resize', queryChatRect);
+  window.addEventListener('resize', () => {queryChatRect; setTimeout(queryChatRect, 475);});
   window.addEventListener('focus', queryChatRect);
   window.addEventListener('mouseup', () => setTimeout(queryChatRect, 10));
 


### PR DESCRIPTION
Added devicepixelratio to message passed to Chatterino app. This allows the app to adjust the x position of the attached window even when the host window is zoomed in (a problem in Chrome).

Also added an additional delayed call to queryChatRect because, on Chrome, Twitch has an animation when you zoom that takes about 475ms to complete. This makes it so you don't have to resize/click on the window to adjust chat size after zooming. 

Goes with: https://github.com/Chatterino/chatterino2/pull/1936