### PR TITLE
feat: display a warning when not on Windows

### DIFF
--- a/background.js
+++ b/background.js
@@ -190,6 +190,16 @@ chrome.runtime.onMessage.addListener((message, sender, callback) => {
       updateBadge();
 
       break;
+    case 'get-os':
+      chrome.runtime.getPlatformInfo((info) => {
+        callback(info.os);
+      });
+
+      // We need to return true here so that `callback` will remain valid
+      // after this function returns. This behavior is documented here:
+      // https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onMessage
+      return true;
+      break;
     case 'location-updated':
       chrome.windows.get(sender.tab.windowId, {}, (window) => {
         if (!window.focused) return;

--- a/inject.js
+++ b/inject.js
@@ -190,6 +190,13 @@
   function updateErrors() {
     if (!errorDiv) return;
 
+    if (errors.osUnsupported) {
+     errorDiv.innerHTML =
+       "The Chatterino Native Host browser extension currently only works on Windows.";
+
+     return;
+    }
+
     let closeButton =
       '<div onclick="document.getElementsByClassName(`right-column__toggle-visibility`)[0].children[0].children[0].click()" style="padding:5px; left: -30px; width: 30px; height: 30px; background: #222;z-index: 100;cursor: pointer;top: 10px;position: absolute;transform: rotateZ(180deg);color: white;"><svg class="tw-icon__svg" width="100%" height="100%" version="1.1" viewBox="0 0 20 20" x="0px" y="0px"><g><path fill="#bbbbbb" d="M16 16V4h2v12h-2zM6 9l2.501-2.5-1.5-1.5-5 5 5 5 1.5-1.5-2.5-2.5h8V9H6z"></path></g></svg></div>'
 
@@ -228,6 +235,22 @@
     errors.sendMessage = true;
     updateErrors();
   }
+
+  try {
+    chrome.runtime.sendMessage({ 'type': 'get-os' }, (os) => {
+      // Available OS string are documented here:
+      // https://developer.chrome.com/docs/extensions/reference/runtime/#type-PlatformOs
+      if (os !== "win") {
+        errors.osUnsupported = true;
+      }
+
+      updateErrors();
+    });
+  } catch {
+    errors.sendMessage = true;
+    updateErrors();
+  }
+
 
   // event listeners
   window.addEventListener('load', () => setTimeout(queryChatRect, 1000));


### PR DESCRIPTION
## Description
Closes #49.

Since only Windows is supported at the time of writing, it makes sense to be display that information when users try to run the extension on anything other than Windows.

This information is also available on the extension settings page, but much more discoverable here.

<details>
<summary>Screenshot</summary>

![Screenshot of warning message on Linux](https://user-images.githubusercontent.com/35232120/103098920-d7dbf300-460c-11eb-91af-5affe17540a4.png)

</details>

## Additional Information
Would be great if someone could test this on Windows and Mac as well.
Code criticism is very welcome as I rarely work with JavaScript and this is my first time hacking away at a browser extension.