### PR TITLE
fix: send `select` action without `attach` when not replacing

### DIFF
--- a/background.js
+++ b/background.js
@@ -253,17 +253,15 @@ chrome.runtime.onMessage.addListener((message, sender, callback) => {
 
 // attach chatterino to a chrome window
 function tryAttach(windowId, fullscreen, data) {
-  if (!settings.all().replaceTwitchChat) {
-    return;
-  }
-
   console.log('tryAttach ' + windowId);
 
   data.action = 'select';
-  if (fullscreen) {
-    data.attach_fullscreen = true;
-  } else {
-    data.attach = true;
+  if (settings.all().replaceTwitchChat) {
+    if (fullscreen) {
+      data.attach_fullscreen = true;
+    } else {
+      data.attach = true;
+    }
   }
   data.type = 'twitch';
   data.winId = '' + windowId;


### PR DESCRIPTION
This will allow users to use the `/watching` channel in Chatterino even if the chat isn't replaced.

This works, because the chat is only created if `attach` or `attach_fullscreen` is set to `true` ([relevant code](https://github.com/Chatterino/chatterino2/blob/a033dbc933ed87fc0d1ca4497c14401b9e16c423/src/singletons/NativeMessaging.cpp#L247-L260)).