### PR TITLE
Update watching tab without replacing chat in browser

### DIFF
--- a/src/inject.js
+++ b/src/inject.js
@@ -58,9 +58,7 @@
   function installChatterino() {
     if (matchChannelName(window.location.href)) {
       showingChat = true;
-      if (settings.replaceTwitchChat) {
-        replaceChat();
-      }
+      replaceChat();
     } else {
       showingChat = false;
       chrome.runtime.sendMessage({ type: 'detach' });


### PR DESCRIPTION
Currently, there is no case where [`tryAttach`](https://github.com/Chatterino/chatterino-browser-ext/blob/master/src/background.js#L252) is called and the setting [`replaceTwitchChat`](https://github.com/Chatterino/chatterino-browser-ext/blob/master/src/background.js#L256) is false since `tryAttach` is only able to be called when `replaceChat` is called. Removing this if condition allows that to happen.

One issue that will need to be addressed in Chatterino is the live ping sound that will fire every time the user switches streams in the browser, regardless if the "watching" tab is open in Chatterino. I suggest muting the "watching" tab completely from live ping sounds since there is no need to have them (or at least put it in a toggleable setting).