### PR TITLE
Remove Usage of `devicePixelRatio`

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -228,8 +228,8 @@ chrome.runtime.onMessage.addListener((message, sender, callback) => {
         // get zoom value
         chrome.tabs.getZoom(sender.tab.id, zoom => {
           let size = {
-            x: message.rect.x,
-            pixelRatio: message.pixelRatio,
+            x: message.rect.x * zoom,
+            pixelRatio: 1,
             width: Math.floor(message.rect.width * zoom),
             height: Math.floor(message.rect.height * zoom),
           };

--- a/src/inject.js
+++ b/src/inject.js
@@ -176,7 +176,6 @@
 
     let data = {
       type: 'chat-resized',
-      pixelRatio: window.devicePixelRatio,
       rect: { x: rect.x, y: rect.y, width: rect.width, height: rect.height },
     };
 


### PR DESCRIPTION
This was added in #28 to detect the zoom-level. This works if the regular DPR is `1`, but breaks on high-dpi monitors.

To adjust for the zoom-level, I added `x: message.rect.x * zoom` which is correct if the zoom level is 1, and mostly right (sometimes 1–12px off, see screenshots). I think the slight offset is tolerable.

| Zoom Level | Screenshot | Diff |
|---|---|---|
|0.9|![image](https://user-images.githubusercontent.com/19953266/227984856-8da07fba-ae35-41ef-b32a-b380719e9683.png)|12px|
|1.0|![image](https://user-images.githubusercontent.com/19953266/227984709-f4bd3ec7-8616-4581-aeba-126439d81824.png) |1px|
|1.1| ![image](https://user-images.githubusercontent.com/19953266/227984248-7e0e2939-3a8b-459a-b558-469bf591f3b6.png) | 7px |
|1.2| ![image](https://user-images.githubusercontent.com/19953266/227985428-6d4cd2f3-14d8-4691-a5e7-e85dd8533b79.png) | 1px |




Fixes #89