### PR TITLE
Sync channels with Chatterino

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -336,7 +336,7 @@ function syncTabs() {
 
     const port = getPort();
     if (port) {
-      port.postMessage({ action: 'sync', twitch: [...currentTabs] });
+      port.postMessage({ action: 'sync', twitchChannels: [...currentTabs] });
     }
   });
 }


### PR DESCRIPTION
In conjunction with https://github.com/Chatterino/chatterino2/pull/4741.

This syncs the channels opened in the browser with Chatterino. It's currently used to warm channels that are open in the browser to make switching between tabs in the browser when the channel isn't open in Chatterino quicker.