### PR TITLE
refactor: migrate to manifest v3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Check formatting
+name: Build
 
 on:
   push:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,83 @@
+name: Check formatting
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: latest
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v3.0.0
+        with:
+          version: latest
+          run_install: true
+
+      - name: Build
+        run: pnpm build
+
+      - name: Zip Firefox
+        run: zip -r ../firefox-unsigned.zip .
+        working-directory: build/firefox
+      - name: Zip Chrome
+        run: zip -r ../chrome-unsigned.zip .
+        working-directory: build/chrome
+
+      - name: Upload Firefox
+        uses: actions/upload-artifact@v4
+        with:
+          name: firefox-unsigned.zip
+          path: build/firefox-unsigned.zip
+      - name: Upload Chrome
+        uses: actions/upload-artifact@v4
+        with:
+          name: chrome-unsigned.zip
+          path: build/chrome-unsigned.zip
+
+  create-release:
+    needs: [build]
+    runs-on: ubuntu-latest
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/master')
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # allows for tags access
+
+      - name: Download Chrome
+        uses: actions/download-artifact@v4
+        with:
+          name: chrome-unsigned.zip
+          path: release-artifacts/
+      - name: Download Firefix
+        uses: actions/download-artifact@v4
+        with:
+          name: firefox-unsigned.zip
+          path: release-artifacts/
+
+      - name: Create release
+        uses: ncipollo/release-action@v1.14.0
+        with:
+          replacesArtifacts: true
+          allowUpdates: true
+          artifactErrorsFailBuild: true
+          artifacts: 'release-artifacts/*'
+          body: ${{ github.event.head_commit.message }}
+          prerelease: true
+          name: Nightly Release
+          tag: nightly-build
+
+      - name: Update nightly-build tag
+        run: |
+          git tag -f nightly-build
+          git push -f origin nightly-build
+        shell: bash

--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: lts
+          node-version: latest
       - name: Setup pnpm
         uses: pnpm/action-setup@v3.0.0
         with:

--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -12,14 +12,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: lts
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v3.0.0
         with:
-          version: 7.x
+          version: latest
           run_install: true
       - run: pnpm run check-format

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 node_modules
+build/
+.vscode
+.idea
+.vs
+.code

--- a/build.mjs
+++ b/build.mjs
@@ -1,0 +1,28 @@
+import fs from 'node:fs/promises';
+
+await fs.rm('build', { recursive: true, force: true }).catch(() => {});
+await fs.mkdir('build');
+await fs.mkdir('build/firefox');
+await fs.mkdir('build/chrome');
+
+await fs.cp('src', 'build/firefox', { recursive: true });
+await fs.cp('src', 'build/chrome', { recursive: true });
+
+const mapManifest = async (path, fn) => {
+  const json = JSON.parse(await fs.readFile(path, 'utf8'));
+  fn(json);
+  await fs.writeFile(path, JSON.stringify(json, null, 2), 'utf8');
+};
+
+// Currently, Firefox doesn't support service workers as background scripts (see
+// https://bugzilla.mozilla.org/show_bug.cgi?id=1573659) and Chrome doesn't
+// support "regular" scripts.
+// The manifest in src/ currently supports both browsers, but will show warnings
+// about unsupported/unknown features. In "release" builds (i.e. builds
+// submitted to the respective store), these unknown keys are deleted.
+mapManifest('build/firefox/manifest.json', json => {
+  delete json.background.service_worker;
+});
+mapManifest('build/chrome/manifest.json', json => {
+  delete json.background.scripts;
+});

--- a/package.json
+++ b/package.json
@@ -3,10 +3,12 @@
   "private": true,
   "scripts": {
     "format": "prettier -w **/*.{md,js,ts,jsx,tsx,html,css,json,yaml,yml}",
-    "check-format": "prettier -c **/*.{md,js,ts,jsx,tsx,html,css,json,yaml,yml}"
+    "check-format": "prettier -c **/*.{md,js,ts,jsx,tsx,html,css,json,yaml,yml}",
+    "build": "node build.mjs"
   },
   "devDependencies": {
     "prettier": "^3.2.5",
-    "@types/chrome": "^0.0.263"
+    "@types/chrome": "^0.0.263",
+    "@types/node": "^20.14.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "check-format": "prettier -c **/*.{md,js,ts,jsx,tsx,html,css,json,yaml,yml}"
   },
   "devDependencies": {
-    "prettier": "^2.7.1"
+    "prettier": "^2.7.1",
+    "@types/chrome": "^0.0.263"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "check-format": "prettier -c **/*.{md,js,ts,jsx,tsx,html,css,json,yaml,yml}"
   },
   "devDependencies": {
-    "prettier": "^2.7.1",
+    "prettier": "^3.2.5",
     "@types/chrome": "^0.0.263"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,42 +1,67 @@
-lockfileVersion: '6.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-devDependencies:
-  '@types/chrome':
-    specifier: ^0.0.263
-    version: 0.0.263
-  prettier:
-    specifier: ^3.2.5
-    version: 3.2.5
+importers:
+
+  .:
+    devDependencies:
+      '@types/chrome':
+        specifier: ^0.0.263
+        version: 0.0.263
+      '@types/node':
+        specifier: ^20.14.2
+        version: 20.14.2
+      prettier:
+        specifier: ^3.2.5
+        version: 3.2.5
 
 packages:
 
-  /@types/chrome@0.0.263:
+  '@types/chrome@0.0.263':
     resolution: {integrity: sha512-As0vzv99ov3M6ZR7R6VzhMWFZXkPMrFrCEXXVrMN576Cm70fTkj7Df2CF+qEo170JepX50pd11cX6O4DSAtl2Q==}
-    dependencies:
-      '@types/filesystem': 0.0.36
-      '@types/har-format': 1.2.15
-    dev: true
 
-  /@types/filesystem@0.0.36:
+  '@types/filesystem@0.0.36':
     resolution: {integrity: sha512-vPDXOZuannb9FZdxgHnqSwAG/jvdGM8Wq+6N4D/d80z+D4HWH+bItqsZaVRQykAn6WEVeEkLm2oQigyHtgb0RA==}
-    dependencies:
-      '@types/filewriter': 0.0.33
-    dev: true
 
-  /@types/filewriter@0.0.33:
+  '@types/filewriter@0.0.33':
     resolution: {integrity: sha512-xFU8ZXTw4gd358lb2jw25nxY9QAgqn2+bKKjKOYfNCzN4DKCFetK7sPtrlpg66Ywe3vWY9FNxprZawAh9wfJ3g==}
-    dev: true
 
-  /@types/har-format@1.2.15:
+  '@types/har-format@1.2.15':
     resolution: {integrity: sha512-RpQH4rXLuvTXKR0zqHq3go0RVXYv/YVqv4TnPH95VbwUxZdQlK1EtcMvQvMpDngHbt13Csh9Z4qT9AbkiQH5BA==}
-    dev: true
 
-  /prettier@3.2.5:
+  '@types/node@20.14.2':
+    resolution: {integrity: sha512-xyu6WAMVwv6AKFLB+e/7ySZVr/0zLCzOa7rSpq6jNwpqOrUbcACDWC+53d4n2QHOnDou0fbIsg8wZu/sxrnI4Q==}
+
+  prettier@3.2.5:
     resolution: {integrity: sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==}
     engines: {node: '>=14'}
     hasBin: true
-    dev: true
+
+  undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+
+snapshots:
+
+  '@types/chrome@0.0.263':
+    dependencies:
+      '@types/filesystem': 0.0.36
+      '@types/har-format': 1.2.15
+
+  '@types/filesystem@0.0.36':
+    dependencies:
+      '@types/filewriter': 0.0.33
+
+  '@types/filewriter@0.0.33': {}
+
+  '@types/har-format@1.2.15': {}
+
+  '@types/node@20.14.2':
+    dependencies:
+      undici-types: 5.26.5
+
+  prettier@3.2.5: {}
+
+  undici-types@5.26.5: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,14 +1,41 @@
-lockfileVersion: 5.4
+lockfileVersion: '6.0'
 
-specifiers:
-  prettier: ^2.7.1
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
 
 devDependencies:
-  prettier: 2.7.1
+  '@types/chrome':
+    specifier: ^0.0.263
+    version: 0.0.263
+  prettier:
+    specifier: ^2.7.1
+    version: 2.7.1
 
 packages:
 
-  /prettier/2.7.1:
+  /@types/chrome@0.0.263:
+    resolution: {integrity: sha512-As0vzv99ov3M6ZR7R6VzhMWFZXkPMrFrCEXXVrMN576Cm70fTkj7Df2CF+qEo170JepX50pd11cX6O4DSAtl2Q==}
+    dependencies:
+      '@types/filesystem': 0.0.36
+      '@types/har-format': 1.2.15
+    dev: true
+
+  /@types/filesystem@0.0.36:
+    resolution: {integrity: sha512-vPDXOZuannb9FZdxgHnqSwAG/jvdGM8Wq+6N4D/d80z+D4HWH+bItqsZaVRQykAn6WEVeEkLm2oQigyHtgb0RA==}
+    dependencies:
+      '@types/filewriter': 0.0.33
+    dev: true
+
+  /@types/filewriter@0.0.33:
+    resolution: {integrity: sha512-xFU8ZXTw4gd358lb2jw25nxY9QAgqn2+bKKjKOYfNCzN4DKCFetK7sPtrlpg66Ywe3vWY9FNxprZawAh9wfJ3g==}
+    dev: true
+
+  /@types/har-format@1.2.15:
+    resolution: {integrity: sha512-RpQH4rXLuvTXKR0zqHq3go0RVXYv/YVqv4TnPH95VbwUxZdQlK1EtcMvQvMpDngHbt13Csh9Z4qT9AbkiQH5BA==}
+    dev: true
+
+  /prettier@2.7.1:
     resolution: {integrity: sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==}
     engines: {node: '>=10.13.0'}
     hasBin: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ devDependencies:
     specifier: ^0.0.263
     version: 0.0.263
   prettier:
-    specifier: ^2.7.1
-    version: 2.7.1
+    specifier: ^3.2.5
+    version: 3.2.5
 
 packages:
 
@@ -35,8 +35,8 @@ packages:
     resolution: {integrity: sha512-RpQH4rXLuvTXKR0zqHq3go0RVXYv/YVqv4TnPH95VbwUxZdQlK1EtcMvQvMpDngHbt13Csh9Z4qT9AbkiQH5BA==}
     dev: true
 
-  /prettier@2.7.1:
-    resolution: {integrity: sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==}
-    engines: {node: '>=10.13.0'}
+  /prettier@3.2.5:
+    resolution: {integrity: sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==}
+    engines: {node: '>=14'}
     hasBin: true
     dev: true

--- a/src/background.js
+++ b/src/background.js
@@ -17,13 +17,51 @@ const ignoredPages = new Set([
   'wallet',
 ]);
 
-const attachedWindows = {};
-// we try to detach every native window once at start in case someone reloaded
-// the extension
-let detachedWindowsCache = {};
+class AttachedWindows {
+  /** @param {number} winID */
+  static async isAttached(winID) {
+    const windows = await AttachedWindows.#load();
+    return winID in windows;
+  }
+
+  /** @param {number} winID */
+  static async markAttached(winID) {
+    const windows = await AttachedWindows.#load();
+    windows[winID] = true;
+    await AttachedWindows.#save(windows);
+  }
+
+  /** @param {number} winID */
+  static async markDetatched(winID) {
+    const windows = await AttachedWindows.#load();
+    delete windows[winID];
+    await AttachedWindows.#save(windows);
+  }
+
+  /** @returns {Promise<number[]>} */
+  static async detachAll() {
+    const windows = await AttachedWindows.#load();
+    await AttachedWindows.#save({});
+    return Object.keys(windows).map(Number);
+  }
+
+  /** @returns {Promise<Record<number, boolean>} */
+  static #load() {
+    return chrome.storage.session
+      .get('attachedWindows')
+      .then(({ attachedWindows }) => attachedWindows ?? {})
+      .catch(() => ({}));
+  }
+
+  /** @param {Promise<Record<number, boolean>} attachedWindows */
+  static #save(attachedWindows) {
+    return chrome.storage.session.set({ attachedWindows }).catch(console.warn);
+  }
+}
+
 const debugCalls = true;
 
-let settings = (() => {
+const settings = (() => {
   const map = { replaceTwitchChat: true };
 
   // load settings
@@ -84,13 +122,11 @@ function connectPort() {
   port = chrome.runtime.connectNative(appName);
   console.log('port connected');
 
-  detachedWindowsCache = {};
-
   port.onMessage.addListener(msg => {
     console.log(msg);
   });
   port.onDisconnect.addListener(xd => {
-    console.log('port disconnected', (xd | {}).error, chrome.runtime.lastError);
+    console.log('port disconnected', xd?.error, chrome.runtime.lastError);
 
     port = null;
   });
@@ -107,73 +143,71 @@ function disconnectPort() {
 }
 
 // tab activated
-chrome.tabs.onActivated.addListener(activeInfo => {
-  chrome.tabs.get(activeInfo.tabId, tab => {
-    if (!tab || !tab.url) return;
+chrome.tabs.onActivated.addListener(async activeInfo => {
+  const tab = await chrome.tabs.get(activeInfo.tabId);
+  if (!tab || !tab.url) return;
 
-    chrome.windows.get(tab.windowId, {}, window => {
-      if (!window.focused) return;
+  const window = await chrome.windows.get(tab.windowId, {});
+  if (!window.focused) return;
 
-      if (debugCalls) console.log('onActivated');
+  if (debugCalls) console.log('onActivated');
 
-      onTabSelected(tab.url, tab);
-    });
-  });
+  await onTabSelected(tab.url, tab);
 });
 
 // url changed
-chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
   if (!tab.highlighted) return;
 
-  chrome.windows.get(tab.windowId, {}, window => {
-    if (!window.focused) return;
+  const window = await chrome.windows.get(tab.windowId, {});
+  if (!window.focused) return;
 
-    if (debugCalls) console.log('onUpdated');
+  if (debugCalls) console.log('onUpdated');
 
-    onTabSelected(tab.url, tab);
-  });
+  onTabSelected(tab.url, tab);
 });
 
 // tab detached
-chrome.tabs.onDetached.addListener((tabId, detachInfo) => {
+chrome.tabs.onDetached.addListener(async (tabId, detachInfo) => {
   if (debugCalls) console.log('onDetached');
 
-  tryDetach(detachInfo.oldWindowId);
+  await tryDetach(detachInfo.oldWindowId);
 });
 
 // tab closed
-chrome.windows.onRemoved.addListener(windowId => {
+chrome.windows.onRemoved.addListener(async windowId => {
   if (debugCalls) console.log('onRemoved');
 
-  tryDetach(windowId);
+  await tryDetach(windowId);
 });
 
 // window selected
-chrome.windows.onFocusChanged.addListener(windowId => {
+chrome.windows.onFocusChanged.addListener(async windowId => {
   console.log(windowId);
   if (windowId == -1) return;
 
   // this returns all tabs when the query fails
-  chrome.tabs.query({ windowId: windowId, highlighted: true }, tabs => {
-    if (tabs.length === 1) {
-      let tab = tabs[0];
-
-      chrome.windows.get(tab.windowId, window => {
-        if (debugCalls) console.log('onFocusChanged');
-
-        onTabSelected(tab.url, tab);
-      });
-    }
+  const tabs = await chrome.tabs.query({
+    windowId: windowId,
+    highlighted: true,
   });
+  if (tabs.length === 1) {
+    let tab = tabs[0];
+
+    const window = await chrome.windows.get(tab.windowId);
+    if (debugCalls) console.log('onFocusChanged');
+
+    await onTabSelected(tab.url, tab);
+  }
 });
 
 // attach or detach from tab
-function onTabSelected(url, tab) {
+async function onTabSelected(url, tab) {
   let channelName = matchChannelName(url);
 
   if (!channelName) {
     // detach from window
-    tryDetach(tab.windowId);
+    await tryDetach(tab.windowId);
   }
 }
 
@@ -186,18 +220,18 @@ chrome.runtime.onMessage.addListener((message, sender, callback) => {
       callback(settings.all());
       break;
     case 'set-setting':
-      settings.set(message.key, message.value);
+      (async () => {
+        settings.set(message.key, message.value);
 
-      for (let id in attachedWindows) {
-        tryDetach(id);
-      }
-      updateBadge();
-
+        for (const id of await AttachedWindows.detachAll()) {
+          // they're already cleared
+          await sendDetach(id);
+        }
+        updateBadge();
+      })();
       break;
     case 'get-os':
-      chrome.runtime.getPlatformInfo(info => {
-        callback(info.os);
-      });
+      chrome.runtime.getPlatformInfo(info => callback(info.os));
 
       // We need to return true here so that `callback` will remain valid
       // after this function returns. This behavior is documented here:
@@ -227,23 +261,22 @@ chrome.runtime.onMessage.addListener((message, sender, callback) => {
       if (!sender.tab.highlighted) return;
 
       // is window focused
-      chrome.windows.get(sender.tab.windowId, {}, window => {
+      chrome.windows.get(sender.tab.windowId, {}, async window => {
         if (!window.focused) return;
 
         // get zoom value
-        chrome.tabs.getZoom(sender.tab.id, zoom => {
-          let size = {
-            x: message.rect.x * zoom,
-            pixelRatio: 1,
-            width: Math.floor(message.rect.width * zoom),
-            height: Math.floor(message.rect.height * zoom),
-          };
+        const zoom = await chrome.tabs.getZoom(sender.tab.id);
+        let size = {
+          x: message.rect.x * zoom,
+          pixelRatio: 1,
+          width: Math.floor(message.rect.width * zoom),
+          height: Math.floor(message.rect.height * zoom),
+        };
 
-          // attach to window
-          tryAttach(sender.tab.windowId, window.state == 'fullscreen', {
-            name: matchChannelName(sender.tab.url),
-            size: size,
-          });
+        // attach to window
+        await tryAttach(sender.tab.windowId, window.state == 'fullscreen', {
+          name: matchChannelName(sender.tab.url),
+          size: size,
         });
       });
       break;
@@ -254,7 +287,7 @@ chrome.runtime.onMessage.addListener((message, sender, callback) => {
 });
 
 // attach chatterino to a chrome window
-function tryAttach(windowId, fullscreen, data) {
+async function tryAttach(windowId, fullscreen, data) {
   console.log('tryAttach ' + windowId);
 
   data.action = 'select';
@@ -275,42 +308,47 @@ function tryAttach(windowId, fullscreen, data) {
     port.postMessage(data);
   }
 
-  attachedWindows[windowId] = {};
+  await AttachedWindows.markAttached(windowId);
 }
 
-// detach chatterino from a chrome window
-function tryDetach(windowId) {
-  if (
-    attachedWindows[windowId] === undefined &&
-    detachedWindowsCache[windowId] !== undefined
-  ) {
-    return;
+/**
+ * Detach chatterino from a chrome window
+ * @param {number} windowId
+ */
+async function tryDetach(windowId) {
+  if (await AttachedWindows.isAttached(windowId)) {
+    sendDetach(windowId);
+    await AttachedWindows.markDetatched(windowId);
   }
+}
 
-  detachedWindowsCache[windowId] = {};
+function sendDetach(winID) {
+  console.log('sendDetach', { winID });
 
-  console.log('tryDetach ' + windowId);
-
-  let port = getPort();
-
+  const port = getPort();
   if (port) {
-    port.postMessage({ action: 'detach', version: 0, winId: '' + windowId });
-  }
-
-  if (attachedWindows[windowId] !== undefined) {
-    delete attachedWindows[windowId];
+    port.postMessage({ action: 'detach', version: 0, winId: winID.toString() });
   }
 }
 
 function updateBadge() {
-  chrome.browserAction.setBadgeText({
+  chrome.action.setBadgeText({
     text: settings.all().replaceTwitchChat ? '' : 'off',
   });
 }
 
-// The previous state sent to chatterino
-let previousTabs = new Set();
-function syncTabs() {
+function getPreviousTabs() {
+  return chrome.storage.session
+    .get('previousTabs')
+    .then(({ previousTabs }) => new Set(previousTabs ?? []))
+    .catch(() => new Set());
+}
+
+async function setPreviousTabs(tabs) {
+  await chrome.storage.session.set({ previousTabs: [...tabs] });
+}
+
+async function syncTabs() {
   function compareTabs(lhs, rhs) {
     if (lhs.size !== rhs.size) {
       return false;
@@ -324,21 +362,24 @@ function syncTabs() {
     return true;
   }
 
-  chrome.tabs.query({ url: '*://*.twitch.tv/*' }, tabs => {
-    const currentTabs = new Set(
-      tabs.map(t => matchChannelName(t.url)).filter(Boolean)
-    );
-    if (compareTabs(previousTabs, currentTabs)) {
-      return;
-    }
-    previousTabs = currentTabs;
-    console.log('sending updated tabs:', currentTabs);
+  let previousTabs = await getPreviousTabs();
 
-    const port = getPort();
-    if (port) {
-      port.postMessage({ action: 'sync', twitchChannels: [...currentTabs] });
-    }
-  });
+  const tabs = await chrome.tabs.query({ url: '*://*.twitch.tv/*' });
+  const currentTabs = new Set(
+    tabs.map(t => matchChannelName(t.url)).filter(Boolean)
+  );
+  if (compareTabs(previousTabs, currentTabs)) {
+    return;
+  }
+  previousTabs = currentTabs;
+  console.log('sending updated tabs:', currentTabs);
+
+  const port = getPort();
+  if (port) {
+    port.postMessage({ action: 'sync', twitchChannels: [...currentTabs] });
+  }
+
+  await setPreviousTabs(previousTabs);
 }
 syncTabs();
 

--- a/src/background.js
+++ b/src/background.js
@@ -366,7 +366,7 @@ async function syncTabs() {
 
   const tabs = await chrome.tabs.query({ url: '*://*.twitch.tv/*' });
   const currentTabs = new Set(
-    tabs.map(t => matchChannelName(t.url)).filter(Boolean)
+    tabs.map(t => matchChannelName(t.url)).filter(Boolean),
   );
   if (compareTabs(previousTabs, currentTabs)) {
     return;

--- a/src/background.js
+++ b/src/background.js
@@ -120,13 +120,29 @@ function getPort() {
 // connect to port
 function connectPort() {
   port = chrome.runtime.connectNative(appName);
-  console.log('port connected');
+  console.debug('port connected');
 
   port.onMessage.addListener(msg => {
-    console.log(msg);
+    if (typeof msg === 'object' && msg.type === 'status') {
+      switch (msg.status) {
+        case 'exiting-host':
+          console.info(
+            `Native host is exiting: '${msg.reason ?? '<unknown>'}'`,
+          );
+          break;
+        default:
+          console.log(msg);
+          break;
+      }
+    } else {
+      console.log(msg);
+    }
   });
-  port.onDisconnect.addListener(xd => {
-    console.log('port disconnected', xd?.error, chrome.runtime.lastError);
+  port.onDisconnect.addListener(e => {
+    console.debug(
+      'port disconnected',
+      e?.error ?? e ?? chrome.runtime.lastError,
+    );
 
     port = null;
   });

--- a/src/inject.js
+++ b/src/inject.js
@@ -28,7 +28,7 @@
     if (!url) return undefined;
 
     const match = url.match(
-      /^https?:\/\/(?:www\.)?twitch\.tv\/(\w+)\/?(?:\?.*)?$/
+      /^https?:\/\/(?:www\.)?twitch\.tv\/(\w+)\/?(?:\?.*)?$/,
     );
 
     let channelName;

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,23 +1,25 @@
 {
+  "$schema": "https://json.schemastore.org/chrome-manifest",
   "name": "Chatterino Native Host",
-  "version": "1.5",
+  "version": "1.6",
   "description": "Replaces the chat on Twitch.tv with Chatterino.",
   "permissions": ["tabs", "nativeMessaging", "storage"],
+  "host_permissions": ["*://*.twitch.tv/*"],
   "icons": {
     "256": "icon.png"
   },
-  "applications": {
+  "browser_specific_settings": {
     "gecko": {
       "id": "chatterino_native@chatterino.com",
       "strict_min_version": "50.0"
     }
   },
-  "manifest_version": 2,
+  "manifest_version": 3,
   "background": {
-    "scripts": ["background.js"],
-    "persistent": true
+    "service_worker": "background.js",
+    "scripts": ["background.js"]
   },
-  "browser_action": {
+  "action": {
     "default_popup": "popup.html"
   },
   "content_scripts": [

--- a/src/popup.html
+++ b/src/popup.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
   <head>
     <style>


### PR DESCRIPTION
Migrates the extension to manifest v3 (required on Chrome from June 2024).

Firefox doesn't support `service_worker` in manifest v3 yet, so `scripts` is used instead (which Chrome doesn't support on v3). The manifest is built conditionally (`pnpm build`).

Tested it on Chrome (latest) and Firefox (nightly).