### PR TITLE
chore: add better support for other operating systems

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -62,22 +62,23 @@ class AttachedWindows {
 const debugCalls = true;
 
 const settings = (() => {
-  const map = { replaceTwitchChat: true };
+  const map = { replaceTwitchChat: false };
 
   // load settings
-  chrome.storage.local.get(Object.keys(map), result => {
-    for (let key in map) {
-      if (result[key] !== undefined) {
-        map[key] = result[key];
+  (async () => {
+    const platform = await chrome.runtime.getPlatformInfo();
+    map.replaceTwitchChat = platform.os === 'win';
+
+    const saved = await chrome.storage.local.get(Object.keys(map));
+    for (const key of Object.keys(map)) {
+      if (saved[key] !== undefined) {
+        map[key] = saved[key];
       }
     }
     updateBadge();
-  });
+  })();
 
   return {
-    get: key => {
-      map[name];
-    },
     set: (key, value) => {
       let obj = {};
       obj[key] = value;

--- a/src/popup.html
+++ b/src/popup.html
@@ -15,8 +15,8 @@
         }
       }
 
-      body:not(.windows) .if-windows,
-      body.windows .if-not-windows {
+      body:not(.chatterino-windows) .chatterino-if-windows,
+      body.chatterino-windows .chatterino-if-not-windows {
         display: none;
       }
     </style>
@@ -32,14 +32,14 @@
 
       <h3>Troubleshooting:</h3>
       <ul>
-        <li class="if-not-windows">
+        <li class="chatterino-if-not-windows">
           Chat replacement is not supported on your OS.
         </li>
         <li>
           Make sure <a href="https://chatterino.com">Chatterino</a> version
-          <span class="if-windows">2.1.1</span
-          ><span class="if-not-windows">2.5.3</span> or later is installed and
-          running on your computer.
+          <span class="chatterino-if-windows">2.1.1</span
+          ><span class="chatterino-if-not-windows">2.5.3</span> or later is
+          installed and running on your computer.
         </li>
         <li>There might be issues with other Twitch related extensions.</li>
       </ul>

--- a/src/popup.html
+++ b/src/popup.html
@@ -4,6 +4,20 @@
     <style>
       body {
         width: 400px;
+        font-family: Arial, Helvetica, sans-serif;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        body {
+          color: #eee;
+          background: #121212;
+          color-scheme: dark;
+        }
+      }
+
+      body:not(.windows) .if-windows,
+      body.windows .if-not-windows {
+        display: none;
       }
     </style>
   </head>
@@ -11,22 +25,25 @@
   <body>
     <div>
       <h3>Settings:</h3>
-      <label
-        ><input id="replace-twitch" type="checkbox" />Replace twitch chat (page
-        reload required)</label
-      >
+      <label>
+        <input id="replace-twitch" type="checkbox" />Replace Twitch chat (page
+        reload required)
+      </label>
 
       <h3>Troubleshooting:</h3>
       <ul>
-        <li>Only Windows is supported!</li>
+        <li class="if-not-windows">
+          Chat replacement is not supported on your OS.
+        </li>
         <li>
           Make sure <a href="https://chatterino.com">Chatterino</a> version
-          2.1.1 or later is installed and running on your computer.
+          <span class="if-windows">2.1.1</span
+          ><span class="if-not-windows">2.5.3</span> or later is installed and
+          running on your computer.
         </li>
-        <li>Chatterino 1 is <u>not</u> supported.</li>
-        <li>There might be issues with other twitch related extensions.</li>
+        <li>There might be issues with other Twitch related extensions.</li>
       </ul>
     </div>
-    <script src="popup.js"></script>
+    <script src="popup.js" type="module"></script>
   </body>
 </html>

--- a/src/popup.js
+++ b/src/popup.js
@@ -12,3 +12,10 @@ chrome.runtime.sendMessage({ type: 'get-settings' }, settings_ => {
     });
   };
 });
+
+const platform = await chrome.runtime.getPlatformInfo();
+if (platform.os === 'win') {
+  document.body.classList.add('windows');
+} else {
+  document.getElementById('min-version').textContent = '2.5.3';
+}

--- a/src/popup.js
+++ b/src/popup.js
@@ -15,7 +15,7 @@ chrome.runtime.sendMessage({ type: 'get-settings' }, settings_ => {
 
 const platform = await chrome.runtime.getPlatformInfo();
 if (platform.os === 'win') {
-  document.body.classList.add('windows');
+  document.body.classList.add('chatterino-windows');
 } else {
   document.getElementById('min-version').textContent = '2.5.3';
 }


### PR DESCRIPTION
Since https://github.com/Chatterino/chatterino2/pull/6031, the `/watching` synchronization is supported on all platforms.

This PR changes the following:

- Only enable `replaceTwitchChat` by default if we're on Windows
- Update settings page to mention that chat replacement is only supported on Windows
- Use the correct minimum version (2.1.1 for Windows, 2.5.3 elsewhere)
- "twitch" → "Twitch"
- Add a dark mode to the settings page