### PR TITLE
fix: support vertical tabs on Firefox

### DIFF
--- a/src/inject.js
+++ b/src/inject.js
@@ -177,6 +177,7 @@
     let data = {
       type: 'chat-resized',
       rect: { x: rect.x, y: rect.y, width: rect.width, height: rect.height },
+      dpr: window.devicePixelRatio,
     };
 
     isCollapsed = rect.width == 0;


### PR DESCRIPTION
The solution is quite hacky but works well for me, even on different zoom levels and different monitor DPI.

Tested on Firefox Nightly and Chrome stable.

Fixes #108.